### PR TITLE
Alterar banco de dados local para nuvem com PostgreeSQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /firebase-config.json
 /migrations
 .env
+migrate_sqlite_to_postgres.py

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -22,7 +22,8 @@ migrate = Migrate()
 
 def create_app():
     app = Flask(__name__, template_folder='../templates', static_folder='../static')
-    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{os.path.join(app.instance_path, "financas.db")}'
+    # app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{os.path.join(app.instance_path, "financas.db")}'
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DB_URI')
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.secret_key = os.getenv('SECRET_KEY')
 


### PR DESCRIPTION
Devido as políticas de hospedagem da Vercel é necessário um banco de dados externo para a aplicação.

Por isso foi criado um banco de dados pela Supabase com PostgreeSQL. https://supabase.com/

Criar uma nova variável de ambiente contendo o acesso ao banco de dados.