### PR TITLE
Melhorar a segurança de transacoes recorrentes

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -599,37 +599,44 @@ def editar_transacao(id):
 
     if not (current_user.is_admin or transacao.user_id == current_user.id):
         abort(403)
-    
-    if request.method == 'POST':
-        transacao.descricao = request.form['descricao']
-        transacao.valor = float(request.form['valor'])
-        transacao.tipo = request.form['tipo']
-        transacao.categoria_id = int(request.form['categoria'])
-        transacao.data = datetime.strptime(request.form['data'], '%Y-%m-%dT%H:%M')
 
-        # Segurança para não permitir alterações em transações recorrentes
-        if transacao.meses_repeticao > 0 and transacao.data_original != transacao.data:
-            flash('Não é possível alterar a data de transações recorrentes já geradas', 'warning')
-            return redirect(url_for('main.editar_transacao', id=id))
-        
-         # Atualiza recorrência
-        novo_recorrente = 'recorrente' in request.form
-        
-        if transacao.recorrente and not novo_recorrente:
-            # Se estava ativo e foi desativado
-            transacao.recorrente = False
-            transacao.meses_repeticao = 0
-            transacao.data_original = None
-        elif not transacao.recorrente and novo_recorrente:
-            # Se estava inativo e foi ativado
-            transacao.recorrente = True
-            transacao.data_original = transacao.data
-            transacao.meses_repeticao = 0
-        
-        db.session.commit()
-        flash('Transação atualizada com sucesso!', 'success')
-        return redirect(url_for('main.listar_transacoes'))
-    
+    if request.method == 'POST':
+        try:
+            csrf.protect()
+            
+            # Atualizar campos básicos
+            transacao.descricao = request.form['descricao']
+            transacao.valor = float(request.form['valor'])
+            transacao.tipo = request.form['tipo']
+            transacao.categoria_id = int(request.form['categoria'])
+            transacao.data = datetime.strptime(request.form['data'], '%Y-%m-%dT%H:%M')
+
+            novo_recorrente = 'recorrente' in request.form
+
+            # Lógica de atualização de recorrência
+            if transacao.recorrente and not novo_recorrente:
+                # Desativar recorrência
+                transacao.recorrente = False
+                transacao.meses_repeticao = 0
+                transacao.data_original = None
+            elif not transacao.recorrente and novo_recorrente:
+                # Ativar recorrência
+                transacao.recorrente = True
+                transacao.data_original = transacao.data  # Define data_original inicial
+                transacao.meses_repeticao = 0
+
+            # Sincroniza data_original se for recorrente e não disparada
+            if transacao.recorrente and transacao.meses_repeticao == 0:
+                transacao.data_original = transacao.data  # Mantém sempre atualizado
+
+            db.session.commit()
+            flash('Transação atualizada com sucesso!', 'success')
+            return redirect(url_for('main.listar_transacoes'))
+
+        except Exception as e:
+            db.session.rollback()
+            flash(f'Erro ao atualizar: {str(e)}', 'danger')
+
     return render_template('editar.html', 
                          transacao=transacao, 
                          categorias=categorias)

--- a/templates/editar.html
+++ b/templates/editar.html
@@ -3,23 +3,30 @@
 {% block content %}
 <h2>Editar Transação</h2>
 
+{% if transacao.meses_repeticao > 0 %}
+<div class="alert alert-warning">
+    Esta transação recorrente já foi processada. Apenas o status de recorrência pode ser alterado.
+</div>
+{% endif %}
+
 <form method="POST">
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <div class="mb-3">
         <label for="descricao" class="form-label">Descrição</label>
         <input type="text" class="form-control" id="descricao" name="descricao" maxlength="100"
-            value="{{ transacao.descricao }}" required>
+            value="{{ transacao.descricao }}" required {% if transacao.meses_repeticao> 0 %}disabled{% endif %}>
     </div>
 
     <div class="mb-3">
         <label for="valor" class="form-label">Valor</label>
         <input type="number" step="0.01" class="form-control" id="valor" name="valor" value="{{ transacao.valor }}"
-            required>
+            required {% if transacao.meses_repeticao> 0 %}disabled{% endif %}>
     </div>
 
     <div class="mb-3">
         <label for="tipo" class="form-label">Tipo</label>
-        <select class="form-select" id="tipo" name="tipo" required>
+        <select class="form-select" id="tipo" name="tipo" required {% if transacao.meses_repeticao> 0 %}disabled{% endif
+            %}>
             <option value="receita" {% if transacao.tipo=='receita' %}selected{% endif %}>Receita</option>
             <option value="despesa" {% if transacao.tipo=='despesa' %}selected{% endif %}>Despesa</option>
         </select>
@@ -27,7 +34,8 @@
 
     <div class="mb-3">
         <label for="categoria" class="form-label">Categoria</label>
-        <select class="form-select" id="categoria" name="categoria" required>
+        <select class="form-select" id="categoria" name="categoria" required {% if transacao.meses_repeticao> 0
+            %}disabled{% endif %}>
             {% for categoria in categorias %}
             <option value="{{ categoria.id }}" {% if categoria.id==transacao.categoria_id %}selected{% endif %}>
                 {{ categoria.nome }}
@@ -39,12 +47,14 @@
     <div class="mb-3">
         <label for="data" class="form-label">Data</label>
         <input type="datetime-local" class="form-control" id="data" name="data"
-            value="{{ transacao.data.strftime('%Y-%m-%dT%H:%M') }}" required>
+            value="{{ transacao.data.strftime('%Y-%m-%dT%H:%M') }}" required {% if transacao.meses_repeticao> 0
+        %}disabled{% endif %}>
     </div>
 
     <div class="mb-3 form-check">
-        <input type="checkbox" class="form-check-input" id="recorrente" name="recorrente" {{ 'checked' if
-            transacao.recorrente else '' }}>
+        <input type="checkbox" class="form-check-input" id="recorrente" name="recorrente" {% if transacao.recorrente
+            %}checked{% endif %}>
+
         <label class="form-check-label" for="recorrente">
             Repetir mensalmente por 1 ano
             {% if transacao.meses_repeticao > 0 %}

--- a/templates/recorrentes.html
+++ b/templates/recorrentes.html
@@ -42,13 +42,13 @@
         <tbody>
             {% for transacao in transacoes %}
             <tr>
-                <td>{{ transacao.descricao }}<i class="bi bi-arrow-repeat" title="Recorrente por 1 ano"></i></td>
+                <td>{{ transacao.descricao }}</td>
                 <td class="{{ 'text-success' if transacao.tipo == 'receita' else 'text-danger' }}">
                     R$ {{ "%.2f"|format(transacao.valor) }}
                 </td>
                 <td>
                     {{ (transacao.data_original + relativedelta(months=+transacao.meses_repeticao+1)).strftime('%d/%m/%Y
-                    %H:%M') }}
+                    %H:%M') }} <i class="bi bi-arrow-repeat" title="Recorrente por 1 ano"></i>
                 </td>
                 <td>{{ 12 - transacao.meses_repeticao }}</td>
                 <td>


### PR DESCRIPTION
Melhorar a segurança de transacoes recorrentes

Possíveis invasões para e erros que podem ser causados em transações recorrentes

Requisitos:
- Uma transação recorrente não pode ser alterada se já foi disparada a recorrência
- Se uma transação recorrente ainda não foi disparada o usuário pode alterar a data e esta será replicada na coluna data_original do banco de dados
- Colocar os ícones de recorrência na coluna de datas da guia recorrentes