### PR TITLE
Adicionar variavel de ambiente para rodar scheduler em producao

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -96,4 +96,9 @@ def create_app():
         from app.routes import main_routes
         app.register_blueprint(main_routes)
 
+     # Iniciar schedulers apenas no processo designado
+    if os.environ.get('FLASK_RUN_SCHEDULER') == '1':
+        from app.routes import start_schedulers
+        start_schedulers(app)
+
     return app

--- a/app/models.py
+++ b/app/models.py
@@ -25,8 +25,6 @@ class Transacao(db.Model):
     tipo = db.Column(db.String(10), nullable=False)
     categoria_id = db.Column(db.Integer, db.ForeignKey('categoria.id'), nullable=False)
     user_id = db.Column(db.String(128), nullable=False)  # Firebase UID do usuário
-
-    # Novos campos para recorrência
     recorrente = db.Column(db.Boolean, default=False)
     meses_repeticao = db.Column(db.Integer, default=0)  # Contador de repetições
     data_original = db.Column(db.DateTime)  # Data da primeira ocorrência

--- a/app/routes.py
+++ b/app/routes.py
@@ -117,17 +117,6 @@ def enviar_alerta(destinatario, nome, receitas, despesas, saldo):
         except Exception as e:
             print(f"Erro ao enviar alerta: {str(e)}")
 
-# Inicializar agendador
-scheduler = BackgroundScheduler()
-scheduler.add_job(
-    func=lambda: verificar_saldos(create_app()),
-    trigger='cron',
-    # day='last', (caso quisesse disparar no ultimo dia do mes)
-    hour=9,
-    minute=0
-)
-scheduler.start()
-
 def criar_transacao_recorrente():
     app = create_app()
 
@@ -170,10 +159,30 @@ def criar_transacao_recorrente():
         
         db.session.commit()
 
-# Agendador que roda diariamente às 00:01
-scheduler = BackgroundScheduler()
-scheduler.add_job(func=criar_transacao_recorrente, trigger='cron', hour=0, minute=5)
-scheduler.start()
+def start_schedulers(app):
+    """Inicia todos os schedulers usando o contexto da aplicação"""
+    with app.app_context():
+        # Agendador de verificação de saldos
+        saldos_scheduler = BackgroundScheduler()
+        saldos_scheduler.add_job(
+            func=verificar_saldos,
+            trigger='cron',
+            hour=11,
+            minute=0
+        )
+        
+        # Agendador de transações recorrentes
+        transacoes_scheduler = BackgroundScheduler()
+        transacoes_scheduler.add_job(
+            func=criar_transacao_recorrente,
+            trigger='cron',
+            hour=0,
+            minute=5
+        )
+        
+        # Iniciar schedulers
+        saldos_scheduler.start()
+        transacoes_scheduler.start()
 
 # Função para promover usuário a admin
 def make_admin(uid):


### PR DESCRIPTION
Scheduler de alertas e ativação de transações recorrentes não estão funcionando. Correção com adição de variável de ambiente em produção